### PR TITLE
v1.21.1

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -40,7 +40,7 @@ jobs:
         uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3.2.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8026d2bc3645ea78b0d2544766a1225eb5691f89 # v3.7.0
+        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
 
       - name: Login to Docker Hub
         if: github.event.ref_type == ('tag'|| 'schedule')

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 FROM yfhme/openssl-docker:v3.3.1@sha256:45914555e17d16c570c55416bca8ed06ffe8734c9037a082f1137cb5fc1a3067 AS build
 
 # renovate: datasource=github-tags depName=NLnetLabs/unbound
-ENV UNBOUND_VERSION=1.21.0
+ENV UNBOUND_VERSION=1.21.1
 ENV UNBOUND_SHA256=e7dca7d6b0f81bdfa6fa64ebf1053b5a999a5ae9278a87ef182425067ea14521
 ENV UNBOUND_DOWNLOAD_URL=https://nlnetlabs.nl/downloads/unbound/unbound-$UNBOUND_VERSION.tar.gz
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM yfhme/openssl-docker:v3.3.1@sha256:45914555e17d16c570c55416bca8ed06ffe8734c
 
 # renovate: datasource=github-tags depName=NLnetLabs/unbound
 ENV UNBOUND_VERSION=1.21.1
-ENV UNBOUND_SHA256=e7dca7d6b0f81bdfa6fa64ebf1053b5a999a5ae9278a87ef182425067ea14521
+ENV UNBOUND_SHA256=3036d23c23622b36d3c87e943117bdec1ac8f819636eb978d806416b0fa9ea46
 ENV UNBOUND_DOWNLOAD_URL=https://nlnetlabs.nl/downloads/unbound/unbound-$UNBOUND_VERSION.tar.gz
 
 ADD --checksum=sha256:$UNBOUND_SHA256 $UNBOUND_DOWNLOAD_URL /tmp/src/


### PR DESCRIPTION
Unbound Version
[chore(deps): update dependency nlnetlabs/unbound to v1.21.1](https://github.com/yfhme/unbound-docker/commit/e6b98f41ae62e498b18d304459112a06279d8c8e)
[chore(deps): update dependency nlnetlabs/unbound to v1.21.1 SHA256](https://github.com/yfhme/unbound-docker/commit/32701aba76e8390c7a5cd3bb9abfb519f571145e)

Dependencies
[chore(deps): update docker/setup-buildx-action action to v3.7.1](https://github.com/yfhme/unbound-docker/commit/4f043702b8b59f076a2010a9b63f95587068c26e)